### PR TITLE
Add email-based password reset

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,3 +79,4 @@ clinics.html # PB19 - Cơ sở thú y
 ├── index.html # Trang chính (chuyển hướng login)
 ├── package.json # Thông tin dependencies
 └── README.md # Tài liệu mô tả dự án
+\n### Cấu hình Email\nTạo file `.env` với biến `EMAIL_USER` và `EMAIL_PASS` để gửi mã khôi phục mật khẩu.

--- a/components/header.html
+++ b/components/header.html
@@ -41,20 +41,35 @@
         </div>
 
         <div class="user-actions">
-          <div class="hotline">
-            <i class="bi bi-telephone-fill"></i> 039.556.0056
+          <div class="dropdown">
+            <a
+              href="#"
+              class="text-white d-flex align-items-center"
+              id="userDropdown"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+            >
+              <i class="bi bi-person-circle"></i>
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+              <li>
+                <a class="dropdown-item" href="/pages/user/profile.html"
+                  >Thông tin cá nhân</a
+                >
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="#"
+                  onclick="localStorage.removeItem('loggedInUser'); window.location.href = '/pages/auth/login.html';"
+                  >Đăng xuất</a
+                >
+              </li>
+            </ul>
           </div>
           <a href="../pages/user/booking.html" class="booking">
             <i class="bi bi-calendar-event"></i> Đặt Lịch
           </a>
-          <!-- <a class="login-btn" href="/index.html">Đăng Nhập</a> -->
-          <a
-            class="logout-btn"
-            href="#"
-            style="display: none"
-            onclick="logoutUser(); window.location.href = '../pages/auth/login.html';"
-            >Đăng Xuất</a
-          >
           <a href="/pages/user/cart.html" class="cart position-relative">
             <i class="bi bi-cart3"></i> Giỏ Hàng
             <span class="cart-count">0</span>

--- a/css/custom.css
+++ b/css/custom.css
@@ -59,11 +59,19 @@ header {
   gap: 15px;
 }
 
-.hotline,
 .booking,
 .cart,
 .login-btn,
 .logout-btn {
+  color: white;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  text-decoration: none;
+}
+
+.user-actions .dropdown > a {
   color: white;
   font-size: 14px;
   display: flex;

--- a/js/auth/forgot-password.js
+++ b/js/auth/forgot-password.js
@@ -1,32 +1,72 @@
-// Tải modal HTML
 fetch('../../components/modal.html')
-    .then(response => response.text())
-    .then(data => {
-        document.getElementById('modalContainer').innerHTML = data;
-    });
+  .then((res) => res.text())
+  .then((html) => {
+    document.getElementById('modalContainer').innerHTML = html;
+  });
 
-function openModal(title, content, onConfirm) {
-    const modal = new bootstrap.Modal(document.getElementById('commonModal'));
-    document.getElementById('commonModalLabel').innerText = title;
-    document.querySelector('.modal-body').innerText = content;
-
-    const confirmBtn = document.getElementById('modalConfirmBtn');
-    confirmBtn.onclick = function () {
-        onConfirm();
-        modal.hide();
-    };
-
-    modal.show();
+function showModal(title, content, onConfirm) {
+  const modal = new bootstrap.Modal(document.getElementById('commonModal'));
+  document.getElementById('commonModalLabel').innerText = title;
+  document.querySelector('#commonModal .modal-body').innerText = content;
+  const btn = document.getElementById('modalConfirmBtn');
+  btn.onclick = () => {
+    if (onConfirm) onConfirm();
+    modal.hide();
+  };
+  modal.show();
 }
 
-document.addEventListener('DOMContentLoaded', function () {
-    // Xử lý form quên mật khẩu
-    document.getElementById('forgotPasswordForm').addEventListener('submit', function (e) {
-        e.preventDefault();
-        const email = document.getElementById('email').value;
-        openModal('Xác Nhận Gửi Liên Kết', `Liên kết đặt lại mật khẩu sẽ được gửi đến ${email}. Bạn có muốn tiếp tục không?`, function () {
-            alert('Liên kết đã được gửi! Vui lòng kiểm tra email.');
-            document.getElementById('forgotPasswordForm').reset();
+document.addEventListener('DOMContentLoaded', () => {
+  const sendForm = document.getElementById('sendCodeForm');
+  const resetForm = document.getElementById('resetForm');
+
+  sendForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('email').value.trim();
+    if (!email) return;
+    try {
+      const res = await fetch('/api/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        showModal('Thành công', 'Mã xác thực đã được gửi tới email của bạn.');
+        sendForm.style.display = 'none';
+        resetForm.style.display = 'block';
+      } else {
+        showModal('Lỗi', data.message || 'Không thể gửi mã xác thực');
+      }
+    } catch (err) {
+      console.error(err);
+      showModal('Lỗi', 'Không thể kết nối tới máy chủ');
+    }
+  });
+
+  resetForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('email').value.trim();
+    const code = document.getElementById('code').value.trim();
+    const newPassword = document.getElementById('newPassword').value.trim();
+    if (!code || !newPassword) return;
+    try {
+      const res = await fetch('/api/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, code, newPassword }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        showModal('Thành công', 'Đặt lại mật khẩu thành công', () => {
+          window.location.href = 'login.html';
         });
-    });
+      } else {
+        showModal('Lỗi', data.message || 'Không thể đặt lại mật khẩu');
+      }
+    } catch (err) {
+      console.error(err);
+      showModal('Lỗi', 'Không thể kết nối tới máy chủ');
+    }
+  });
 });

--- a/js/routes/loginRoute.js
+++ b/js/routes/loginRoute.js
@@ -1,93 +1,134 @@
 const express = require('express');
-const router = express.Router();
+const bcrypt = require('bcryptjs');
+const nodemailer = require('nodemailer');
 const db = require('../db');
 
+const router = express.Router();
+
+// In-memory store for reset codes
+const resetCodes = new Map();
+
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
+  },
+});
 
 router.post('/login', (req, res) => {
   const { email, password } = req.body;
-
   if (!email || !password) {
     return res.status(400).json({ success: false, message: 'Thiếu email hoặc password' });
   }
-
-  const query = 'SELECT * FROM TaiKhoan WHERE Gmail = ? AND MatKhau = ?';
-  db.query(query, [email, password], (err, results) => {
+  const query = 'SELECT * FROM TaiKhoan WHERE Gmail = ?';
+  db.query(query, [email], (err, results) => {
     if (err) {
       console.error('Lỗi login:', err);
       return res.status(500).json({ success: false, message: 'Lỗi database' });
     }
-
-    if (results.length > 0) {
-      const user = results[0];
-      const role = user.ID_ChucVu === 1 ? 'admin' : 'user';
-      return res.json({ 
-        success: true, 
-        user: { ...user, role } 
-      });
-    } else {
+    if (results.length === 0) {
       return res.json({ success: false, message: 'Sai email hoặc password' });
     }
+    const user = results[0];
+    const role = user.ID_ChucVu === 1 ? 'admin' : 'user';
+    bcrypt.compare(password, user.MatKhau, (err, match) => {
+      if (err || !match) {
+        return res.json({ success: false, message: 'Sai email hoặc password' });
+      }
+      return res.json({ success: true, user: { ...user, role } });
+    });
   });
 });
 
 router.post('/register', (req, res) => {
   const { hoTen, gmail, dienThoai, matKhau, chucVu } = req.body;
-
   if (!hoTen || !gmail || !matKhau) {
-    return res.status(400).json({ 
-      success: false, 
-      message: 'Thiếu thông tin bắt buộc: Họ tên, email và mật khẩu' 
-    });
+    return res.status(400).json({ success: false, message: 'Thiếu thông tin bắt buộc: Họ tên, email và mật khẩu' });
   }
-
   const checkEmailQuery = 'SELECT ID_TaiKhoan FROM TaiKhoan WHERE Gmail = ?';
   db.query(checkEmailQuery, [gmail], (err, existing) => {
     if (err) {
       console.error('Lỗi kiểm tra email:', err);
-      return res.status(500).json({ 
-        success: false, 
-        message: 'Lỗi kiểm tra email' 
-      });
+      return res.status(500).json({ success: false, message: 'Lỗi kiểm tra email' });
     }
-
     if (existing.length > 0) {
-      return res.status(400).json({ 
-        success: false, 
-        message: 'Email này đã được sử dụng' 
-      });
+      return res.status(400).json({ success: false, message: 'Email này đã được sử dụng' });
     }
-
-    const insertQuery = `
-      INSERT INTO TaiKhoan (HoTen, Gmail, DienThoai, MatKhau, ID_ChucVu) 
-      VALUES (?, ?, ?, ?, ?)
-    `;
-    
-    db.query(insertQuery, [
-      hoTen, 
-      gmail, 
-      dienThoai || null, 
-      matKhau, 
-      chucVu || 3  
-    ], (err, result) => {
+    bcrypt.hash(matKhau, 10, (err, hash) => {
       if (err) {
-        console.error('Lỗi tạo tài khoản:', err);
-        return res.status(500).json({ 
-          success: false, 
-          message: 'Lỗi tạo tài khoản' 
-        });
+        console.error('Lỗi hash mật khẩu:', err);
+        return res.status(500).json({ success: false, message: 'Lỗi tạo tài khoản' });
       }
-
-      console.log('Tạo tài khoản thành công, ID:', result.insertId);
-      return res.json({ 
-        success: true, 
-        message: 'Đăng ký tài khoản thành công',
-        userId: result.insertId
+      const insertQuery = 'INSERT INTO TaiKhoan (HoTen, Gmail, DienThoai, MatKhau, ID_ChucVu) VALUES (?, ?, ?, ?, ?)';
+      db.query(insertQuery, [hoTen, gmail, dienThoai || null, hash, chucVu || 3], (err2, result) => {
+        if (err2) {
+          console.error('Lỗi tạo tài khoản:', err2);
+          return res.status(500).json({ success: false, message: 'Lỗi tạo tài khoản' });
+        }
+        console.log('Tạo tài khoản thành công, ID:', result.insertId);
+        return res.json({ success: true, message: 'Đăng ký tài khoản thành công', userId: result.insertId });
       });
     });
   });
 });
 
+router.post('/forgot-password', (req, res) => {
+  const { email } = req.body;
+  if (!email) {
+    return res.status(400).json({ success: false, message: 'Thiếu email' });
+  }
+  const query = 'SELECT ID_TaiKhoan FROM TaiKhoan WHERE Gmail = ?';
+  db.query(query, [email], (err, results) => {
+    if (err) {
+      console.error('Lỗi tìm email:', err);
+      return res.status(500).json({ success: false, message: 'Lỗi database' });
+    }
+    if (results.length === 0) {
+      return res.status(404).json({ success: false, message: 'Email không tồn tại' });
+    }
+    const code = Math.floor(100000 + Math.random() * 900000).toString();
+    resetCodes.set(email, { code, expires: Date.now() + 15 * 60 * 1000 });
+    const mailOptions = {
+      from: process.env.EMAIL_USER,
+      to: email,
+      subject: 'Mã đặt lại mật khẩu',
+      text: `Mã xác thực của bạn là: ${code}. Mã có hiệu lực trong 15 phút.`,
+    };
+    transporter.sendMail(mailOptions, (err2) => {
+      if (err2) {
+        console.error('Lỗi gửi email:', err2);
+        return res.status(500).json({ success: false, message: 'Không gửi được email' });
+      }
+      return res.json({ success: true, message: 'Đã gửi mã xác thực' });
+    });
+  });
+});
 
-
+router.post('/reset-password', (req, res) => {
+  const { email, code, newPassword } = req.body;
+  if (!email || !code || !newPassword) {
+    return res.status(400).json({ success: false, message: 'Thiếu thông tin' });
+  }
+  const entry = resetCodes.get(email);
+  if (!entry || entry.code !== code || entry.expires < Date.now()) {
+    return res.status(400).json({ success: false, message: 'Mã xác thực không hợp lệ hoặc đã hết hạn' });
+  }
+  resetCodes.delete(email);
+  bcrypt.hash(newPassword, 10, (err, hash) => {
+    if (err) {
+      console.error('Lỗi hash mật khẩu:', err);
+      return res.status(500).json({ success: false, message: 'Lỗi cập nhật mật khẩu' });
+    }
+    const updateQuery = 'UPDATE TaiKhoan SET MatKhau = ? WHERE Gmail = ?';
+    db.query(updateQuery, [hash, email], (err2) => {
+      if (err2) {
+        console.error('Lỗi cập nhật mật khẩu:', err2);
+        return res.status(500).json({ success: false, message: 'Không thể cập nhật mật khẩu' });
+      }
+      return res.json({ success: true, message: 'Đặt lại mật khẩu thành công' });
+    });
+  });
+});
 
 module.exports = router;

--- a/pages/auth/forgot-password.html
+++ b/pages/auth/forgot-password.html
@@ -17,8 +17,8 @@
                     <div class="card auth-card">
                         <div class="card-body">
                             <h2 class="text-center mb-4">Quên Mật Khẩu</h2>
-                            <p class="text-center text-muted mb-4">Nhập email của bạn để nhận liên kết đặt lại mật khẩu.</p>
-                            <form id="forgotPasswordForm">
+                            <p class="text-center text-muted mb-4">Nhập email của bạn để nhận mã đặt lại mật khẩu.</p>
+                            <form id="sendCodeForm">
                                 <div class="mb-3">
                                     <label for="email" class="form-label">Email</label>
                                     <div class="input-group">
@@ -26,8 +26,27 @@
                                         <input type="email" id="email" class="form-control" placeholder="Nhập email" required>
                                     </div>
                                 </div>
-                                <button type="submit" class="btn btn-primary w-100">
-                                    <i class="fas fa-paper-plane"></i> Gửi Liên Kết
+                                <button type="submit" class="btn btn-primary w-100" id="sendCodeBtn">
+                                    <i class="fas fa-paper-plane"></i> Gửi Mã
+                                </button>
+                            </form>
+                            <form id="resetForm" style="display:none" class="mt-3">
+                                <div class="mb-3">
+                                    <label for="code" class="form-label">Mã xác thực</label>
+                                    <div class="input-group">
+                                        <span class="input-group-text"><i class="fas fa-key"></i></span>
+                                        <input type="text" id="code" class="form-control" placeholder="Nhập mã" required>
+                                    </div>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="newPassword" class="form-label">Mật khẩu mới</label>
+                                    <div class="input-group">
+                                        <span class="input-group-text"><i class="fas fa-lock"></i></span>
+                                        <input type="password" id="newPassword" class="form-control" placeholder="Mật khẩu mới" required>
+                                    </div>
+                                </div>
+                                <button type="submit" class="btn btn-success w-100" id="resetBtn">
+                                    <i class="fas fa-check"></i> Đặt Lại Mật Khẩu
                                 </button>
                             </form>
                             <p class="text-center mt-3">Quay lại <a href="login.html">Đăng nhập</a></p>


### PR DESCRIPTION
## Summary
- implement hashed passwords and password reset with email verification code
- update forgot password page and script for 2-step reset
- document email environment variables

## Testing
- `npm test` *(fails: Missing script)*